### PR TITLE
Manutencao Perfectiva para verificacao dos nomes de autores

### DIFF
--- a/src/main/java/net/sf/jabref/logic/integrity/IntegrityCheck.java
+++ b/src/main/java/net/sf/jabref/logic/integrity/IntegrityCheck.java
@@ -168,12 +168,30 @@ public class IntegrityCheck {
                         return Collections.emptyList();
                     }
 
-                    String valueTrimmedAndLowerCase = value.get().trim().toLowerCase();
-                    if (valueTrimmedAndLowerCase.startsWith("and ") || valueTrimmedAndLowerCase.startsWith(",")) {
-                        result.add(new IntegrityMessage(Localization.lang("should start with a name"), entry, field));
-                    } else if (valueTrimmedAndLowerCase.endsWith(" and") || valueTrimmedAndLowerCase.endsWith(",")) {
-                        result.add(new IntegrityMessage(Localization.lang("should end with a name"), entry, field));
+                    String valueTrimmed = value.get().trim();
+                    String valueTrimmedAndLowerCase = valueTrimmed.toLowerCase();
+
+                    if (valueTrimmedAndLowerCase.isEmpty()) {
+                        result.add(new IntegrityMessage(Localization.lang("should start with an upper letter"), entry,
+                                field));
                     }
+                    else {
+                        if (!(Character.isUpperCase(valueTrimmed.charAt(0)))) {
+                        result.add(new IntegrityMessage(Localization.lang("should start with an upper letter"), entry,
+                                field));
+                        }
+                        if (!(Character.isLetter(valueTrimmed.charAt(0)))) {
+                            result.add(new IntegrityMessage(Localization.lang("should start with a letter"), entry,
+                                    field));
+                        }
+                        if (valueTrimmedAndLowerCase.startsWith("and ") || valueTrimmedAndLowerCase.startsWith(",")) {
+                        result.add(new IntegrityMessage(Localization.lang("should start with a name"), entry, field));
+                        } else if (valueTrimmedAndLowerCase.endsWith(" and")
+                                || valueTrimmedAndLowerCase.endsWith(",")) {
+                        result.add(new IntegrityMessage(Localization.lang("should end with a name"), entry, field));
+                        }
+                    }
+
                 }
             }
             return result;

--- a/src/test/java/net/sf/jabref/logic/integrity/IntegrityCheckTest.java
+++ b/src/test/java/net/sf/jabref/logic/integrity/IntegrityCheckTest.java
@@ -60,12 +60,14 @@ public class IntegrityCheckTest {
     @Test
     public void testAuthorNameChecks() {
         for (String field : InternalBibtexFields.BIBLATEX_PERSON_NAME_FIELDS) {
-            assertCorrect(createContext(field, ""));
             assertCorrect(createContext(field, "Knuth"));
             assertCorrect(createContext(field, "   Knuth, Donald E. "));
             assertCorrect(createContext(field, "Knuth, Donald E. and Kurt Cobain and A. Einstein"));
             assertCorrect(createContext(field, "Donald E. Knuth and Kurt Cobain and A. Einstein"));
             assertWrong(createContext(field, ", and Kurt Cobain and A. Einstein"));
+            assertWrong(createContext(field, "a eistein"));
+            assertWrong(createContext(field, " 2 eistein"));
+            assertWrong(createContext(field, ""));
             assertWrong(createContext(field, "Donald E. Knuth and Kurt Cobain and ,"));
             assertWrong(createContext(field, "and Kurt Cobain and A. Einstein"));
             assertWrong(createContext(field, "Donald E. Knuth and Kurt Cobain and"));


### PR DESCRIPTION
Valida o nome de autores e campos relativos a pessoas. Verifica se os nomes começam por letras maiúsculas.